### PR TITLE
Updating script to create Abra-Collaboratory based project

### DIFF
--- a/create_new_project.sh
+++ b/create_new_project.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+echo "Before running this script you must:"
+echo "   1) Create a new repository to serve as your Abra-Collaboratory framework based repository"
+echo "   2) Create the first wiki page in your repository manually."
+
+read -p "Are you ready to continue (y/n)? " -n 1 -r
+echo    # (optional) move to a new line
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
+fi
+
 if [ $# != 2 ]
   then
     echo "Please provide user name and project name"
@@ -18,6 +29,16 @@ mv Abra-Collaboratory/resources/New_Collaborators_Invitation_Email.md resources/
 
 rm -rf Abra-Collaboratory/
 
+git add .
+git commit -m "Added Abra-C framework files"
+
+find . -type f ! -path '*/\.git/*' -exec sed -i 's/callahantiff/{$USER_NAME}/g' {} \;
+find . -type f ! -path '*/\.git/*' -exec sed -i 's/Abra-Collaboratory/{$PROJECT_NAME}/g' {} \;
+
+git add .
+git commit -m "Updated links and assignees"
+git push
+
 git clone https://github.com/callahantiff/Abra-Collaboratory.wiki.git
 cd Abra-Collaboratory.wiki
 rm Home.md
@@ -27,12 +48,6 @@ rm Using-GitHub-as-a-Reproducible-Research-Platform.md
 
 git add .
 git commit -m "Removed Abra-C specific files"
-
-find . -type f -exec sed -i 's/callahantiff/{$USER_NAME}/g' {} \;
-find . -type f -exec sed -i 's/Abra-Collaboratory/{$PROJECT_NAME}/g' {} \;
-
-git add .
-git commit -m "Replaced links"
 
 git remote add wiki-fork https://github.com/${USER_NAME}/${PROJECT_NAME}.wiki.git
 git push wiki-fork -f


### PR DESCRIPTION
find and replace username and project name in more places; also now that Wiki has relative links, no need to update links/project name.

also added pre-steps to script.

Warning: Script still only works with GNU versions of find/sed; so doesn't work with default macOS find/sed.